### PR TITLE
Rev html5-lint to v0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "html5-lint": "0.2.1",
+    "html5-lint": "0.2.2",
     "nunjucks": "0.1.9"
   },
   "devDependencies": {


### PR DESCRIPTION
After merging this patch, you should push a new tag up, and update anything that depends on this module
