### PR TITLE
Update html5-lint NPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "html5-lint": "0.2.3",
+    "html5-lint": "0.2.5",
     "nunjucks": "0.1.9"
   },
   "devDependencies": {


### PR DESCRIPTION
The version of html5-lint being used has a deprecated dependency, which causes a warning on install. Updating fixes that.